### PR TITLE
Host Python 2/3: Fix SSL support

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -289,7 +289,7 @@ define PyPackage/python/filespec
 endef
 
 HOST_LDFLAGS += \
-	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
+	-Wl$(comma)-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
 
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -286,7 +286,7 @@ define Py3Package/python3/filespec
 endef
 
 HOST_LDFLAGS += \
-	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
+	-Wl$(comma)-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
 
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \


### PR DESCRIPTION

Compile tested: arm_cortex-a9_glibc-2.27_eabi
Run tested: arm_cortex-a9_glibc-2.27_eabi
