### PR TITLE
net/tunsafe: new package

### DIFF
--- a/net/tunsafe/Makefile
+++ b/net/tunsafe/Makefile
@@ -1,0 +1,81 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tunsafe
+PKG_VERSION:=1.5rc2
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/TunSafe/TunSafe.git
+PKG_SOURCE_DATE:=2018-12-17
+PKG_SOURCE_VERSION:=85a871c1d226956df7c1308a1e5527556fe35fe1
+PKG_MIRROR_HASH:=7db72774b760f9ab30bb5e8aee20973c638b4e4ee495d578e0cac26e90c15ffe
+
+PKG_MAINTAINER:=Raif Atef <beliskner.github.3psil0N@neverbox.com>
+PKG_LICENSE:=AGPL-1.0-only
+PKG_LICENSE_FILES:=LICENSE.AGPL.TXT
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tunsafe
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  TITLE:=TunSafe
+  URL:=https://www.tunsafe.com/
+  DEPENDS:=@(x86_64||(arm&&!TARGET_armv5_3_2)) +librt +libstdcpp
+endef
+
+define Package/tunsafe/description
+A high performance and secure VPN client that uses the WireGuard protocol. TunSafe makes 
+it extremely simple to setup blazingly fast and secure VPN tunnels between Windows and Linux.
+This is a user-mode implementation that also supports non-standard obfuscation and TCP mode.
+endef
+
+define Build/Compile
+	if [ "$(ARCH)" == "arm" ]; then \
+		cd $(PKG_BUILD_DIR) && $(TARGET_CXX) -I. -DNDEBUG -DWITH_NETWORK_BSD=1 \
+			-fno-omit-frame-pointer -pthread -lrt -std=c++11 \
+			$(TARGET_LDFLAGS) \
+			tunsafe_amalgam.cpp \
+			crypto/chacha20/chacha20-arm-linux.S \
+			crypto/poly1305/poly1305-arm-linux.S \
+			-o tunsafe; \
+	elif [ "$(ARCH)" == "x86_64" ]; then \
+		cd $(PKG_BUILD_DIR) && $(TARGET_CXX) -I. -DNDEBUG -DWITH_NETWORK_BSD=1 \
+			-pthread -lrt -std=c++11 \
+			$(TARGET_LDFLAGS) \
+			tunsafe_amalgam.cpp \
+			crypto/aesgcm/aesni_gcm-x64-linux.s \
+			crypto/aesgcm/aesni-x64-linux.s \
+			crypto/aesgcm/ghash-x64-linux.s \
+			crypto/poly1305/poly1305-x64-linux.s \
+			crypto/chacha20/chacha20-x64-linux.s \
+			-o tunsafe; \
+	else \
+		echo "unsupported compile target: $(ARCH)"; \
+		exit 1; \
+	fi;
+	
+	cd $(PKG_BUILD_DIR) && $(STRIP) tunsafe
+endef
+
+define Build/Install
+endef
+
+define Package/tunsafe/install
+	$(INSTALL_DIR) $(1)/opt/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tunsafe $(1)/opt/sbin
+	$(INSTALL_DIR) $(1)/opt/etc/tunsafe
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/installer/TunSafe.conf $(1)/opt/etc/tunsafe/main.conf
+	$(INSTALL_DIR) $(1)/opt/etc/init.d
+	$(INSTALL_BIN) ./files/S30tunsafe $(1)/opt/etc/init.d
+endef
+
+define Package/tunsafe/conffiles
+/opt/etc/tunsafe/main.conf
+endef
+
+$(eval $(call BuildPackage,tunsafe))

--- a/net/tunsafe/files/S30tunsafe
+++ b/net/tunsafe/files/S30tunsafe
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+ENABLED=yes
+PROCS=tunsafe
+ARGS="/opt/etc/tunsafe/main.conf"
+PREARGS=""
+DESC=$PROCS
+PATH=/opt/sbin:/opt/bin:/opt/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ -z "$(which $PROCS)" ] && exit 0
+
+. /opt/etc/init.d/rc.func

--- a/net/tunsafe/patches/0001-compile-error-fix.diff
+++ b/net/tunsafe/patches/0001-compile-error-fix.diff
@@ -1,0 +1,13 @@
+diff --git a/tunsafe_bsd.cpp b/tunsafe_bsd.cpp
+index 17f855c..2772d06 100644
+--- a/tunsafe_bsd.cpp
++++ b/tunsafe_bsd.cpp
+@@ -36,7 +36,7 @@
+ #include <net/if_tun.h>
+ #include <net/if_dl.h>
+ #elif defined(OS_LINUX)
+-#include <linux/if.h>
++// #include <linux/if.h>
+ #include <linux/if_tun.h>
+ #include <sys/prctl.h>
+ #include <linux/rtnetlink.h> 

--- a/net/tunsafe/patches/0002-arm-neon-detection.diff
+++ b/net/tunsafe/patches/0002-arm-neon-detection.diff
@@ -1,0 +1,17 @@
+diff --git a/tunsafe_cpu.h b/tunsafe_cpu.h
+index c19f6b1..2347ce3 100644
+--- a/tunsafe_cpu.h
++++ b/tunsafe_cpu.h
+@@ -32,7 +32,11 @@ extern uint32 x86_pcap[3];
+ 
+ extern uint32 arm_pcap[1];
+ 
+-#define ARM_PCAP_NEON (arm_pcap[0] & (1 << 0))
++#if defined(__ARM_NEON__) || defined(__ARM_NEON)
++	#define ARM_PCAP_NEON (arm_pcap[0] & (1 << 0))
++#else
++	#define ARM_PCAP_NEON 0
++#endif
+ 
+ #endif  // defined(ARCH_CPU_ARM_FAMILY)
+ 

--- a/net/tunsafe/patches/0003-handle-different-paths-of-ip.diff
+++ b/net/tunsafe/patches/0003-handle-different-paths-of-ip.diff
@@ -1,0 +1,60 @@
+diff --git a/tunsafe_bsd.cpp b/tunsafe_bsd.cpp
+index 17f855c..eb158db 100644
+--- a/tunsafe_bsd.cpp
++++ b/tunsafe_bsd.cpp
+@@ -367,9 +367,9 @@ static void AddOrRemoveRoute(const RouteInfo &cd, bool remove) {
+   const char *cmd = remove ? "del" : "add";
+   const char *proto = (cd.family == AF_INET) ? NULL : "-6";
+   if (cd.dev.empty()) {
+-    RunCommand("/sbin/ip %s route %s %s via %s", proto, cmd, buf1, buf2);
++    RunCommand("ip %s route %s %s via %s", proto, cmd, buf1, buf2);
+   } else {
+-    RunCommand("/sbin/ip %s route %s %s dev %s", proto, cmd, buf1, cd.dev.c_str());
++    RunCommand("ip %s route %s %s dev %s", proto, cmd, buf1, cd.dev.c_str());
+   }
+ #elif defined(OS_MACOSX) || defined(OS_FREEBSD)
+   const char *cmd = remove ? "delete" : "add";
+@@ -436,10 +436,10 @@ bool TunsafeBackendBsd::Configure(const TunConfig &&config, TunConfigOut *out) o
+   addresses_to_remove_ = config.addresses;
+ 
+ #if defined(OS_LINUX)
+-  RunCommand("/sbin/ip address flush dev %s scope global", devname_);
++  RunCommand("ip address flush dev %s scope global", devname_);
+   for(const WgCidrAddr &a : config.addresses)
+-    RunCommand("/sbin/ip address add dev %s %s", devname_, print_ip_prefix(buf, a.size == 32 ? AF_INET : AF_INET6, a.addr, a.cidr));
+-  RunCommand("/sbin/ip link set dev %s mtu %d up", devname_, config.mtu);
++    RunCommand("ip address add dev %s %s", devname_, print_ip_prefix(buf, a.size == 32 ? AF_INET : AF_INET6, a.addr, a.cidr));
++  RunCommand("ip link set dev %s mtu %d up", devname_, config.mtu);
+ #else
+   for(const WgCidrAddr &a : config.addresses) {
+     if (a.size == 32) {
+@@ -515,7 +515,7 @@ void TunsafeBackendBsd::CleanupRoutes() {
+ 
+ #if defined(OS_LINUX)
+   for(const WgCidrAddr &a : addresses_to_remove_)
+-    RunCommand("/sbin/ip address del dev %s %s", devname_, print_ip_prefix(buf, a.size == 32 ? AF_INET : AF_INET6, a.addr, a.cidr));
++    RunCommand("ip address del dev %s %s", devname_, print_ip_prefix(buf, a.size == 32 ? AF_INET : AF_INET6, a.addr, a.cidr));
+ #else
+   for(const WgCidrAddr &a : addresses_to_remove_) {
+     if (a.size == 32) {
+diff --git a/util.cpp b/util.cpp
+index 11add66..5e0ff27 100644
+--- a/util.cpp
++++ b/util.cpp
+@@ -148,7 +148,6 @@ int RunCommand(const char *fmt, ...) {
+   std::string tmp;
+   char buf[32], c;
+   char *args[33];
+-  char *envp[1] = {NULL};
+   int nargs = 0;
+   bool didadd = false;
+   va_start(va, fmt);
+@@ -194,7 +193,7 @@ ZERO:
+ #if defined(OS_POSIX)
+   pid_t pid = fork();
+   if (pid == 0) {
+-    execve(args[0], args, envp);
++    execvp(args[0], args);
+     exit(127);
+   }
+   if (pid < 0) {


### PR DESCRIPTION
Signed-off-by: Raif Atef <beliskner.github.3psil0N@neverbox.com>

Compile tested: armv7 2.6 kernel softfloat, x86_64 3.2 kernel
Run tested: Netgear R7000 FreshTomato ARM 2020.1

This is a package for TunSafe, a popular Wireguard user-mode implementation that performs well and also supports non-standard features such as obfuscation and TCP mode (very useful for people behind deep censorship systems such as China).

The upstream package only supports arm cortex-a9 (neon and non-neon) and intel x86_64 with AES-NI instructions due to low-level assembly implementation of crypto functions specific to those architectures.
