### PR TITLE
utils/fuse: use /opt/etc/fuse.conf in fusermount

### DIFF
--- a/utils/fuse/patches/300-fusermount-conf-opt-etc.patch
+++ b/utils/fuse/patches/300-fusermount-conf-opt-etc.patch
@@ -1,0 +1,11 @@
+--- a/util/fusermount.c	2021-02-20 19:40:28.469256093 +0000
++++ b/util/fusermount.c	2021-02-20 19:40:41.499255476 +0000
+@@ -37,7 +37,7 @@
+ #define FUSE_DEV_OLD "/proc/fs/fuse/dev"
+ #define FUSE_DEV_NEW "/dev/fuse"
+ #define FUSE_VERSION_FILE_OLD "/proc/fs/fuse/version"
+-#define FUSE_CONF "/etc/fuse.conf"
++#define FUSE_CONF "/opt/etc/fuse.conf"
+ 
+ #ifndef MS_DIRSYNC
+ #define MS_DIRSYNC 128


### PR DESCRIPTION
fusermount assumes that the configuration file fuse.conf is
located at /etc/fuse.conf which is incorrect for Entware.

Fixes the following problem:
/opt/bin/fusermount: option allow_user only allowed if 'user_allow_other' is
set in /etc/fuse.conf

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>

-------------------------------

Compile tested: armv7-3.2, cortex a9
Run tested: armv7-3.2, cortex a9, tested with gocryptfs
