### PR TITLE
Add a patch to make BIND9 work on pre-2.6.37

### DIFF
--- a/net/bind/patches-2.6/500-k26.patch
+++ b/net/bind/patches-2.6/500-k26.patch
@@ -1,0 +1,11 @@
+--- a/lib/isc/netmgr/netmgr.c
++++ b/lib/isc/netmgr/netmgr.c
+@@ -3154,7 +3154,7 @@ isc__nm_socket_connectiontimeout(uv_os_sock_t fd, int timeout_ms) {
+ 	if (setsockopt(fd, IPPROTO_TCP, TIMEOUT_OPTNAME, &timeout,
+ 		       sizeof(timeout)) == -1)
+ 	{
+-		return (ISC_R_FAILURE);
++		return (ISC_R_SUCCESS);
+ 	}
+ 
+ 	return (ISC_R_SUCCESS);


### PR DESCRIPTION
This commit makes a precompiled version of BIND9 and its supplementary
tools not to abort on Linux kernels older than 2.6.37.  Before that,
BIND9 and its tools could abort when establishing a TCP-based DNS
transport connection.

The problem was related to the absence of TCP_USER_TIMEOUT socket
option on older versions of Linux. The fix makes the code apply this
option on the best-effort basis rather than require it.
