### PR TITLE
 net/zerotier: bump to 1.8.4

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
-PKG_VERSION:=1.8.3
+PKG_VERSION:=1.8.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=f0813900c812910db2751bfb43d22a06f11dbcfbe4515e6b24fcad90ca46f665
+PKG_HASH:=61b8c1ea5904cc87431939212033bb4d05d11f517860a01cac75f0090d94272b
 PKG_BUILD_DIR:=$(BUILD_DIR)/ZeroTierOne-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
1.8.4 Contains runtime fixes for older ARM32 chips [CHANGELOG](https://github.com/zerotier/ZeroTierOne/blob/master/RELEASE-NOTES.md)

Compile tested: x86, x86_64, armv5, armv7l, mips32, mips64
Run tested: x86, x86_64, armv5, armv7l, mips32, mips64 --- selftest
