### PR TITLE
fuse,fuse3:Add /opt to fuse mount binary path

### DIFF
--- a/utils/fuse/Makefile
+++ b/utils/fuse/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=fuse
 PKG_VERSION:=2.9.9
-PKG_RELEASE:=1a
+PKG_RELEASE:=1b
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libfuse/libfuse/releases/download/$(PKG_NAME)-$(PKG_VERSION)

--- a/utils/fuse/patches/501-mount_util_bin_path.patch
+++ b/utils/fuse/patches/501-mount_util_bin_path.patch
@@ -1,0 +1,18 @@
+--- a/lib/mount_util.c
++++ b/lib/mount_util.c
+@@ -98,13 +98,13 @@
+ 	if (res == 0) {
+ 		char *env = NULL;
+ 
+ 		sigprocmask(SIG_SETMASK, &oldmask, NULL);
+ 		setuid(geteuid());
+-		execle("/bin/mount", "/bin/mount", "--no-canonicalize", "-i",
++		execle("/opt/bin/mount", "/opt/bin/mount", "--no-canonicalize", "-i",
+ 		       "-f", "-t", type, "-o", opts, fsname, mnt, NULL, &env);
+-		fprintf(stderr, "%s: failed to execute /bin/mount: %s\n",
++		fprintf(stderr, "%s: failed to execute /opt/bin/mount: %s\n",
+ 			progname, strerror(errno));
+ 		exit(1);
+ 	}
+ 	res = waitpid(res, &status, 0);
+ 	if (res == -1)

--- a/utils/fuse3/Makefile
+++ b/utils/fuse3/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=fuse3
 PKG_VERSION:=3.10.5
-PKG_RELEASE:=1
+PKG_RELEASE:=1b
 
 PKG_SOURCE:=fuse-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/libfuse/libfuse/releases/download/fuse-$(PKG_VERSION)

--- a/utils/fuse3/patches/501-mount_util_bin_path.patch
+++ b/utils/fuse3/patches/501-mount_util_bin_path.patch
@@ -1,0 +1,61 @@
+--- a/lib/mount_util.c
++++ b/lib/mount_util.c
+@@ -111,15 +111,15 @@
+ 		if(setuid(geteuid()) == -1) {
+ 			fprintf(stderr, "%s: setuid: %s\n", progname, strerror(errno));
+ 			res = -1;
+ 			goto out_restore;
+ 		}
+ 
+-		execle("/bin/mount", "/bin/mount", "--no-canonicalize", "-i",
++		execle("/opt/bin/mount", "/opt/bin/mount", "--no-canonicalize", "-i",
+ 		       "-f", "-t", type, "-o", opts, fsname, mnt, NULL, &env);
+-		fprintf(stderr, "%s: failed to execute /bin/mount: %s\n",
++		fprintf(stderr, "%s: failed to execute /opt/bin/mount: %s\n",
+ 			progname, strerror(errno));
+ 		exit(1);
+ 	}
+ 	res = waitpid(res, &status, 0);
+ 	if (res == -1)
+ 		fprintf(stderr, "%s: waitpid: %s\n", progname, strerror(errno));
+@@ -171,19 +171,19 @@
+ 			fprintf(stderr, "%s: setuid: %s\n", progname, strerror(errno));
+ 			res = -1;
+ 			goto out_restore;
+ 		}
+ 
+ 		if (lazy) {
+-			execle("/bin/umount", "/bin/umount", "-i", rel_mnt,
++			execle("/opt/bin/umount", "/opt/bin/umount", "-i", rel_mnt,
+ 			       "-l", NULL, &env);
+ 		} else {
+-			execle("/bin/umount", "/bin/umount", "-i", rel_mnt,
++			execle("/opt/bin/umount", "/opt/bin/umount", "-i", rel_mnt,
+ 			       NULL, &env);
+ 		}
+-		fprintf(stderr, "%s: failed to execute /bin/umount: %s\n",
++		fprintf(stderr, "%s: failed to execute /opt/bin/umount: %s\n",
+ 			progname, strerror(errno));
+ 		exit(1);
+ 	}
+ 	res = waitpid(res, &status, 0);
+ 	if (res == -1)
+ 		fprintf(stderr, "%s: waitpid: %s\n", progname, strerror(errno));
+@@ -242,15 +242,15 @@
+ 		if(setuid(geteuid()) == -1) {
+ 			fprintf(stderr, "%s: setuid: %s\n", progname, strerror(errno));
+ 			res = -1;
+ 			goto out_restore;
+ 		}
+ 
+-		execle("/bin/umount", "/bin/umount", "--no-canonicalize", "-i",
++		execle("/opt/bin/umount", "/opt/bin/umount", "--no-canonicalize", "-i",
+ 		       "--fake", mnt, NULL, &env);
+-		fprintf(stderr, "%s: failed to execute /bin/umount: %s\n",
++		fprintf(stderr, "%s: failed to execute /opt/bin/umount: %s\n",
+ 			progname, strerror(errno));
+ 		exit(1);
+ 	}
+ 	res = waitpid(res, &status, 0);
+ 	if (res == -1)
+ 		fprintf(stderr, "%s: waitpid: %s\n", progname, strerror(errno));


### PR DESCRIPTION
Compile tested: x86-64
Run tested: x86-64

I am using Entware on QNAP nas, and it provides a very outdated mount binary. Using the mount-utils provided by Entware will reslove `--no-canonicalize` issue on my system.
It using `execle` to run mount binary, so it works if I crate a symbolic link using `ln -s /bin/mount /opt/bin/mount`(tested locally), but I am not farmilar with install scripts.