### PR TITLE
net/sslh: sync with OpenWrt, 2022.04

### DIFF
--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sslh
-PKG_VERSION:=v1.21c
-PKG_RELEASE:=1a
+PKG_VERSION:=v1.22c
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://rutschle.net/tech/sslh/
-PKG_HASH:=3bfe783726f82c1f5a4be630ddc494ebb08dbb69980662cd7ffdeb7bc9e1e706
+PKG_HASH:=8e3742d14edf4119350cfdc7bb96b89134d9218eb6d2a6e1f70891ca18a649b1
 
 PKG_MAINTAINER:=Jonathan McCrohan <jmccrohan@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -26,7 +26,7 @@ define Package/sslh
   CATEGORY:=Network
   SUBMENU:=Routing and Redirection
   TITLE:=SSL/SSH multiplexer
-  DEPENDS:=+libconfig +libcap +USE_UCLIBC:libpcre +USE_MUSL:libpcre
+  DEPENDS:=+libconfig +libcap +libpcre2
   URL:=https://rutschle.net/tech/sslh/README.html
 endef
 
@@ -35,8 +35,7 @@ define Package/sslh/conffiles
 endef
 
 MAKE_FLAGS += \
-  USELIBCAP=1 \
-  $(if $(CONFIG_USE_GLIBC),USELIBPCRE=,USELIBPCRE=1)
+  USELIBCAP=1
 
 define Package/sslh/install
 	$(INSTALL_DIR) $(1)/opt/sbin

--- a/net/sslh/patches/001-no_sslh_select.patch
+++ b/net/sslh/patches/001-no_sslh_select.patch
@@ -1,27 +1,27 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -76,7 +76,7 @@ all: sslh $(MAN) echosrv $(CONDITIONAL_T
+@@ -70,7 +70,7 @@ all: sslh $(MAN) echosrv $(CONDITIONAL_T
  version.h:
  	./genver.sh >version.h
  
 -sslh: sslh-fork sslh-select
 +sslh: sslh-fork
  
- $(OBJS): version.h
+ $(OBJS): version.h common.h collection.h sslh-conf.h gap.h
  
-@@ -87,10 +87,6 @@ sslh-fork: version.h $(OBJS) sslh-fork.o
+@@ -81,10 +81,6 @@ sslh-fork: version.h $(OBJS) sslh-fork.o
  	$(CC) $(CFLAGS) $(LDFLAGS) -o sslh-fork sslh-fork.o $(OBJS) $(LIBS)
  	#strip sslh-fork
  
--sslh-select: version.h $(OBJS) sslh-select.o Makefile common.h
+-sslh-select: version.h $(OBJS) sslh-select.o Makefile
 -	$(CC) $(CFLAGS) $(LDFLAGS) -o sslh-select sslh-select.o $(OBJS) $(LIBS)
 -	#strip sslh-select
 -
  systemd-sslh-generator: systemd-sslh-generator.o
  	$(CC) $(CFLAGS) $(LDFLAGS) -o systemd-sslh-generator systemd-sslh-generator.o -lconfig
  
-@@ -127,7 +123,7 @@ distclean: clean
- 	rm -f tags sslh-conf.c sslh-conf.h cscope.*
+@@ -133,7 +129,7 @@ distclean: clean
+ 	rm -f tags sslh-conf.[ch] echosrv-conf.[ch] cscope.*
  
  clean:
 -	rm -f sslh-fork sslh-select echosrv version.h $(MAN) systemd-sslh-generator *.o *.gcov *.gcno *.gcda *.png *.html *.css *.info


### PR DESCRIPTION
Change notes:
	Reference openwrt/packages commit: 9b90bb37ee1a6be8da60fb1d4142b7803006d991

	Updated Makefile package version and hash.
	Added libpcre2 dependency
	Removed USELIBPCRE make flag (no longer optional within sslh)
	Updated patch 001 to work with new sslh Makefile

Signed-off-by: Martin Moreno <fett3270@yahoo.com>

Compile tested: armv7-3.2
Run tested: armv7-3.2, Broadcom BCM4708A0
