### PR TITLE
Fix conflict with Keenetic WebDav server

### DIFF
--- a/net/lighttpd/files/S80lighttpd
+++ b/net/lighttpd/files/S80lighttpd
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ENABLED=yes
-PROCS=lighttpd
+PROCS=/opt/sbin/lighttpd
 ARGS="-f /opt/etc/lighttpd/lighttpd.conf"
 PREARGS=""
 DESC=$PROCS


### PR DESCRIPTION
Keenetic WevDav server uses lighttpd installed to `/usr/sbin/lighttpd`.
With installed WebDav, lighttpd from opkg not working because of broken file resolution in init script.

Compile tested: Keenetic KN-1811, aarch64
Run tested: Keenetic KN-1811, aarch64
